### PR TITLE
Problems with QVariant and some undefined functions on Linux...

### DIFF
--- a/common/cqtmfc.cpp
+++ b/common/cqtmfc.cpp
@@ -19,6 +19,8 @@ CWinApp* ptrToTheApp;
 
 CBrush nullBrush;
 
+using namespace qtmfc_workaround;
+
 HGDIOBJ GetStockObject(
    int fnObject
 )
@@ -10880,7 +10882,7 @@ BOOL CMenu::AppendMenu(
          action->setEnabled(true);
       }
       QObject::connect(action,SIGNAL(triggered()),this,SLOT(menuAction_triggered()));
-      action->setData(nIDNewItem);
+      action->setData((uint_ptr)nIDNewItem);
       mfcToQtMenu.insert(nIDNewItem,action);
       qtToMfcMenu.insert(action,nIDNewItem);
    }
@@ -10952,7 +10954,7 @@ BOOL CMenu::InsertMenu(
             action->setEnabled(true);
          }
          QObject::connect(action,SIGNAL(triggered()),this,SLOT(menuAction_triggered()));
-         action->setData(nIDNewItem);
+         action->setData((uint_ptr)nIDNewItem);
          mfcToQtMenu.insert(nIDNewItem,action);
          qtToMfcMenu.insert(action,nIDNewItem);
       }

--- a/common/cqtmfc.h
+++ b/common/cqtmfc.h
@@ -2283,6 +2283,16 @@ typedef int* POSITION;
 
 #define _huge
 
+namespace qtmfc_workaround
+{
+template <size_t szof> struct uint_ptr_select;
+template <>            struct uint_ptr_select<4u> { typedef unsigned int type; };
+template <>            struct uint_ptr_select<8u> { typedef qulonglong   type; };
+
+typedef uint_ptr_select<sizeof(UINT_PTR)>::type uint_ptr;
+
+}
+
 HCURSOR WINAPI SetCursor(
    HCURSOR hCursor
 );

--- a/libs/famitracker/Source/AboutDlg.cpp
+++ b/libs/famitracker/Source/AboutDlg.cpp
@@ -50,7 +50,8 @@ HBRUSH CLinkLabel::CtlColor(CDC* pDC, UINT /*nCtlColor*/)
 
 void CLinkLabel::OnLButtonUp(UINT nFlags, CPoint point)
 {
-	ShellExecute(NULL, _T("open"), m_strAddress, NULL, NULL, SW_SHOWNORMAL);
+    // FIX: Need a definition for: ShellExecute
+	// ShellExecute(NULL, _T("open"), m_strAddress, NULL, NULL, SW_SHOWNORMAL);
 	CStatic::OnLButtonUp(nFlags, point);
 }
 
@@ -79,7 +80,8 @@ void CLinkLabel::OnMouseMove(UINT nFlags, CPoint point)
 		t.cbSize = sizeof(TRACKMOUSEEVENT);
 		t.dwFlags = TME_LEAVE;
 		t.hwndTrack = m_hWnd;
-		TrackMouseEvent(&t);
+        // FIX: Need a definition for: TrackMouseEvent
+		// TrackMouseEvent(&t);
 	}
 
 	CStatic::OnMouseMove(nFlags, point);

--- a/libs/famitracker/Source/ExportDialog.cpp
+++ b/libs/famitracker/Source/ExportDialog.cpp
@@ -377,7 +377,8 @@ void CExportDialog::OnBnClickedPlay()
 	Compiler.ExportNSF(file, (IsDlgButtonChecked(IDC_PAL) != 0));
 
 	// Play exported file (available in debug)
-	ShellExecute(NULL, _T("open"), file, NULL, NULL, SW_SHOWNORMAL);
+    // FIX: Need a definition for: ShellExecute
+	// ShellExecute(NULL, _T("open"), file, NULL, NULL, SW_SHOWNORMAL);
 
 #endif
 }


### PR DESCRIPTION
# Fixes for libfamitracker and nesicide

2 small changes here:
- QVariant has ctor overloads for `int`, `unsigned int`, `qlonglong` (`long long int`) and `qulonglong` (`unsigned long long int`), but no `unsigned long int` overload. As a result, (implicit) calls to QVariant ctor with `UINT_PTR` arguments are ambiguous. Fix: those problematic implicit ctor calls cast the `UINT_PTR` value to `uint_ptr`, a typedef hidden in a namespace `qtmfc_workaround`; `uint_ptr` is `unsigned int` or `qulonglong` depending on the size of `UINT_PTR`;
- Commented-out calls to `ShellExecute` and `TrackMouseEvent`: they are currently undefined.

Sorry for the noise.
