### PR TITLE
Updates QActions to conform to actual constructor.

### DIFF
--- a/apps/ide/mainwindow.cpp
+++ b/apps/ide/mainwindow.cpp
@@ -372,8 +372,9 @@ qDebug("envdat %s\n",envdat.toLatin1().data());
    m_menuRecentFiles = new QMenu("Recent Projects/Files...",menuProject);
    for ( idx = 0; idx < MAX_RECENT_FILES; idx++ )
    {
-      QAction* action = new QAction("Recent File "+QString::number(idx+1), m_menuRecentFiles);
+      QAction* action = new QAction("Recent File "+QString::number(idx+1), nullptr);
       QObject::connect(action,SIGNAL(triggered(bool)),this,SLOT(openRecentFile()));
+      m_menuRecentFiles->addAction(action);
    }
    menuRecent_Projects_Files->addActions(m_menuRecentFiles->actions());
 

--- a/apps/ide/mainwindow.cpp
+++ b/apps/ide/mainwindow.cpp
@@ -372,9 +372,8 @@ qDebug("envdat %s\n",envdat.toLatin1().data());
    m_menuRecentFiles = new QMenu("Recent Projects/Files...",menuProject);
    for ( idx = 0; idx < MAX_RECENT_FILES; idx++ )
    {
-      QAction* action = new QAction("Recent File "+QString::number(idx+1));
+      QAction* action = new QAction("Recent File "+QString::number(idx+1), m_menuRecentFiles);
       QObject::connect(action,SIGNAL(triggered(bool)),this,SLOT(openRecentFile()));
-      m_menuRecentFiles->addAction(action);
    }
    menuRecent_Projects_Files->addActions(m_menuRecentFiles->actions());
 

--- a/apps/nes-emulator/mainwindow.cpp
+++ b/apps/nes-emulator/mainwindow.cpp
@@ -95,7 +95,7 @@ MainWindow::MainWindow(QWidget* parent) :
    ui->actionRecent_Files_STOP->setVisible(false);
    for ( idx = 0; idx < MAX_RECENT_FILES; idx++ )
    {
-      QAction* action = new QAction("Recent File "+QString::number(idx+1));
+      QAction* action = new QAction("Recent File "+QString::number(idx+1), ui->menuFile);
       QObject::connect(action,SIGNAL(triggered(bool)),this,SLOT(openRecentFile()));
       ui->menuFile->insertAction(ui->actionRecent_Files_START,action);
       m_recentFileActions.append(action);

--- a/apps/nes-emulator/mainwindow.cpp
+++ b/apps/nes-emulator/mainwindow.cpp
@@ -95,7 +95,7 @@ MainWindow::MainWindow(QWidget* parent) :
    ui->actionRecent_Files_STOP->setVisible(false);
    for ( idx = 0; idx < MAX_RECENT_FILES; idx++ )
    {
-      QAction* action = new QAction("Recent File "+QString::number(idx+1), ui->menuFile);
+      QAction* action = new QAction("Recent File "+QString::number(idx+1), nullptr);
       QObject::connect(action,SIGNAL(triggered(bool)),this,SLOT(openRecentFile()));
       ui->menuFile->insertAction(ui->actionRecent_Files_START,action);
       m_recentFileActions.append(action);


### PR DESCRIPTION
In trying to get this to build on OSX 10.12.6, I had to make these modifications. According to the docs (http://doc.qt.io/archives/qt-5.6/qaction.html), I'm not sure how this was building previously, given that the constructor signature doesn't match your instantiation.

This will likely need to be modified, as I don't usually use Qt, so I just threw code at the problem till it built.
  