### PR TITLE
Fix missing hex-decode in rc2qt.py

### DIFF
--- a/tools/rc2qt/rc2qt.py
+++ b/tools/rc2qt/rc2qt.py
@@ -4,7 +4,7 @@ from rcVisitor import rcVisitor
 from rcParser import rcParser
 import sys
 import io
-import codecs
+from binascii import unhexlify
 
 class rcBitmap(object):
 	id = None
@@ -849,7 +849,7 @@ class rcDialogInitList(object):
 					for item in items:
 						if len(item)%2:
 							item += "0"
-						print(self.DialogInitItemFormat.format(mfc,item))#.decode('hex')))
+						print(self.DialogInitItemFormat.format(mfc, unhexlify(item)))
 
 class myRcVisitor(rcVisitor):
 	def visitToolbar_statement(self, ctx):


### PR DESCRIPTION
You also have a bunch of trailing whitespace which I didn't remove in this PR.

Maybe you should call rc2qt as a build step, or in CI, to make sure it's up-to-date, and visualize exactly what has changed. I'm not experienced with implementing automated differential testing though.