### PR TITLE
Gitignore all Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,7 @@ moc_*
 *.moc
 qrc_*
 *.exe
-Makefile.Debug
-Makefile
-Makefile.Release
+**/Makefile*
 */.directory
 deps/
 compiler/lex.asm.c
@@ -39,6 +37,3 @@ rcParser*
 rcVisitor*
 rcListener*
 /build/nesicide-deps.tar.bz2
-
-/apps/famitracker/Makefile*
-/libs/famitracker/Makefile*


### PR DESCRIPTION
Before this change the following build artifacts aren't properly ignored
(at least on Mac OS):

    apps/ide/Makefile.nesicide
    apps/nes-emulator/Makefile.nesicide-emulator
    libs/c64/Makefile.c64-emulator-lib
    libs/nes/Makefile.nes-emulator-lib

Instead of listing them one by one I went ahead and used a wildcard.
There are no Makefiles in the repository so this change doesn't affect
any tracked files.